### PR TITLE
trans: ion-textareaコンポーネントの翻訳

### DIFF
--- a/src/translate/api/textarea.readme.md
+++ b/src/translate/api/textarea.readme.md
@@ -1,9 +1,10 @@
 # ion-textarea
 
-The textarea component is used for multi-line text input. A native textarea element is rendered inside of the component. The user experience and interactivity of the textarea component is improved by having control over the native textarea.
+textareaコンポーネントは複数行テキストの入力のためのコンポーネントです。
+ネイティブのtextarea要素がこのコンポーネントの内部に描画されます。
+ネイティブのtextareaを制御することによって、textareaコンポーネントのユーザ体験と対話性が向上します。
 
-Unlike the native textarea element, the Ionic textarea does not support loading its value from the inner content. The textarea value should be set in the `value` attribute.
+ネイティブのtextarea要素とは異なり、Ionicのtextareaは要素内部のコンテンツからその値を読み込むことをサポートしていません。
+textareaの値は`value`属性で設定しなくてはなりません。
 
-The textarea component accepts the [native textarea attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea) in addition to the Ionic properties.
-
-
+textareaコンポーネントはIonicのプロパティに加えて[ネイティブのtextareaの属性](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea)に対応します。

--- a/src/translate/api/textarea.readme.md
+++ b/src/translate/api/textarea.readme.md
@@ -1,10 +1,7 @@
 # ion-textarea
 
-textareaコンポーネントは複数行テキストの入力のためのコンポーネントです。
-ネイティブのtextarea要素がこのコンポーネントの内部に描画されます。
-ネイティブのtextareaを制御することによって、textareaコンポーネントのユーザ体験と対話性が向上します。
+textareaコンポーネントは複数行テキストの入力のためのコンポーネントです。ネイティブのtextarea要素がこのコンポーネントの内部に描画されます。ネイティブのtextareaを制御することによって、textareaコンポーネントのユーザ体験と対話性が向上します。
 
-ネイティブのtextarea要素とは異なり、Ionicのtextareaは要素内部のコンテンツからその値を読み込むことをサポートしていません。
-textareaの値は`value`属性で設定しなくてはなりません。
+ネイティブのtextarea要素とは異なり、Ionicのtextareaは要素内部のコンテンツからその値を読み込むことをサポートしていません。textareaの値は`value`属性で設定しなくてはなりません。
 
 textareaコンポーネントはIonicのプロパティに加えて[ネイティブのtextareaの属性](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea)に対応します。


### PR DESCRIPTION
#23 で宣言していた`ion-textarea`コンポーネントの翻訳です。

初めての翻訳のPRなので、訳し方等改善点があればぜひご指摘ください。