### PR TITLE
chore: set "private": false in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ionic-docs",
   "version": "0.0.0",
-  "private": true,
+  "private": false,
   "engines": {
     "node": ">=20.0.0"
   },


### PR DESCRIPTION
Set `"private": false` in `package.json` to reflect that this repository is **public** on GitHub.